### PR TITLE
- attempt to add support for n_views >=3

### DIFF
--- a/run.py
+++ b/run.py
@@ -47,14 +47,14 @@ parser.add_argument('--log-every-n-steps', default=100, type=int,
                     help='Log every n steps')
 parser.add_argument('--temperature', default=0.07, type=float,
                     help='softmax temperature (default: 0.07)')
-parser.add_argument('--n-views', default=2, type=int, metavar='N',
+parser.add_argument('--n-views', default=4, type=int, metavar='N',
                     help='Number of views for contrastive learning training.')
 parser.add_argument('--gpu-index', default=0, type=int, help='Gpu index.')
 
 
 def main():
     args = parser.parse_args()
-    assert args.n_views == 2, "Only two view training is supported. Please use --n-views 2."
+    # assert args.n_views == 2, "Only two view training is supported. Please use --n-views 2."
     # check if gpu training is available
     if not args.disable_cuda and torch.cuda.is_available():
         args.device = torch.device('cuda')


### PR DESCRIPTION
@sthalles @alessiamarcolini @butyuhao 
Hi,

as mentioned in #32 , the current implementation of info_nce_loss may not properly work if n_views > 2 due to the additional positive pairs. Herein I attempt to fix it by duplicate the negative pairs for additional positive ones, if I understand the mechanism of your current implementation correctly:

```
        positives = similarity_matrix[labels.bool()].view(labels.shape[0] * (n_views - 1), -1)

        # select only the negatives
        # change: copy if n_views > 2 for other positive pairs of img
        negatives = similarity_matrix[~labels.bool()].view(similarity_matrix.shape[0], -1).repeat(n_views - 1, 1)

        logits = torch.cat([positives, negatives], dim=1)
```